### PR TITLE
Add ability to use pip

### DIFF
--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -8,8 +8,18 @@ on:
       mypy-system-dependencies:
         required: false
         type: string
+      package-manager:
+        default: pipenv
+        description: Package manager to use (pip or pipenv)
+        required: false
+        type: string
       python-version:
         default: "3.10"
+        required: false
+        type: string
+      requirements-files:
+        default: requirements.txt
+        description: Space-separated list of requirements files if using pip
         required: false
         type: string
 
@@ -40,11 +50,31 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          cache: pipenv
+          cache: ${{ inputs.package-manager }}
           python-version: ${{ inputs.python-version }}
-      - name: Install Pipenv
-        run: pip install pipenv
-      - name: Run isort
+      # Make sure there is some version of isort in case it's not a listed dependency.
+      - name: Install isort
+        run: pip install isort
+      - name: Install pipenv requirements
+        if: inputs.package-manager == 'pipenv'
+        run: pip install pipenv && pipenv install --dev
+      - name: Install pip requirements
+        if: inputs.package-manager == 'pip'
+        run: pip install -r ${{ inputs.requirements-files }}
+      - name: Run isort (pip)
+        if: inputs.package-manager == 'pip'
+        run: python -m isort --check-only --diff .
+      - name: Run isort (pipenv)
+        if: inputs.package-manager == 'pipenv'
+        run: pipenv run isort --check-only --diff .
+      - name: Run isort (pip)
+        if: inputs.package-manager == 'pip'
+        uses: liskin/gh-problem-matcher-wrap@v1
+        with:
+          linters: isort
+          run: python -m isort --check-only --diff .
+      - name: Run isort (pipenv)
+        if: inputs.package-manager == 'pipenv'
         uses: liskin/gh-problem-matcher-wrap@v1
         with:
           linters: isort
@@ -61,20 +91,34 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          cache: pipenv
+          cache: ${{ inputs.package-manager }}
           python-version: ${{ inputs.python-version }}
-      - name: Install Pipenv
-        run: pip install pipenv
       - name: Set up environment
         if: ${{ inputs.mypy-dot-env }}
         run: cp ${{ inputs.mypy-dot-env }} .env
+      # Make sure there is some version of mypy in case it's not a listed dependency.
+      - name: Install mypy
+        run: pip install mypy
+      - name: Install pipenv requirements
+        if: inputs.package-manager == 'pipenv'
+        run: pip install pipenv && pipenv install --dev
+      - name: Install pip requirements
+        if: inputs.package-manager == 'pip'
+        run: pip install -r ${{ inputs.requirements-files }}
       - name: Load mypy cache
         id: mypy-cache
         uses: actions/cache@v2
         with:
           path: .mypy_cache
           key: mypy-${{ runner.os }}
-      - name: Run mypy
+      - name: Run mypy (pip)
+        if: inputs.package-manager == 'pip'
+        uses: liskin/gh-problem-matcher-wrap@v1
+        with:
+          linters: mypy
+          run: python -m mypy --show-column-numbers
+      - name: Run mypy (pipenv)
+        if: inputs.package-manager == 'pipenv'
         uses: liskin/gh-problem-matcher-wrap@v1
         with:
           linters: mypy


### PR DESCRIPTION
I want to get linting and tests working in our GSEE fork, but there's no reason to use pipenv there. I borrowed some config I use myself: https://github.com/knyghty/actions/ - so I am reasonably confident this should work, but keep in mind this could break things for the other repos if I messed it up. Should be easy to fix though if I did. Or we could start using e.g. `v1`, `v2` tags etc. and use those. But this is probably fine to just be merged and I'll fix anything broken directly.