### PR TITLE
Don't remove local .venv if present for a project.

### DIFF
--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -219,8 +219,8 @@ jobs:
           sudo apt-get -y update
           sudo apt-get -y install --no-install-recommends ${{ inputs.mypy-system-dependencies }}
       - uses: actions/checkout@v3
-      - name: Ensure virtualenv is not created in the project
-        run: rm -rf .venv
+      - name: Ensure virtualenv is empty (if present)
+        run: rm -rf .venv/*
       - uses: actions/setup-python@v4
         with:
           cache: ${{ inputs.package-manager }}


### PR DESCRIPTION
Pyright may be configured to use it, so leave it intact. (e.g. zuos-data uses a local .venv for typing dependencies)