### PR TITLE
Add `--all-extras` option for poetry installation

### DIFF
--- a/python-package-manager/install-dependencies/poetry/action.yml
+++ b/python-package-manager/install-dependencies/poetry/action.yml
@@ -26,5 +26,5 @@ runs:
       run: poetry self add "keyrings-google-artifactregistry-auth@latest"
       shell: bash
     - name: Install poetry dependencies
-      run: poetry install --no-interaction --no-root
+      run: poetry install --all-extras --no-interaction --no-root
       shell: bash


### PR DESCRIPTION
Add `--all-extras` option for poetry installation to make sure all optional dependencies are installed for testing and linting