### PR TITLE
New workflow to build and publish a poetry package from a PR.

### DIFF
--- a/.github/workflows/poetry-publish.yml
+++ b/.github/workflows/poetry-publish.yml
@@ -1,0 +1,194 @@
+name: Poetry publish package
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        default: "3.11"
+        required: false
+        type: string
+    secrets:
+      GOOGLE_AUTHENTICATION_CREDENTIALS_JSON:
+        description: "Google Cloud Platform service-agent JSON credentials for accessing our Artifact Repository and installing private packages."
+        required: false
+
+jobs:
+  diff:
+    # Check for changes which should trigger a new build/publish
+    runs-on: ubuntu-latest
+    outputs:
+      src_changed: ${{ steps.diff.outputs.lines }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: technote-space/get-diff-action@v6
+        id: diff
+        with:
+          GET_FILE_DIFF: true
+          PATTERNS: |
+            src/**/*
+          FILES: |
+            pyproject.toml
+            pyproject.lock
+
+  versions:
+    # Gets the package version from the base and head branches.
+    runs-on: ubuntu-latest
+    outputs:
+      version_base: ${{ steps.version-base.outputs.version }}
+      version_head: ${{ steps.version-head.outputs.version }}
+    steps:
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ inputs.python-version }}
+      - run: pipx install poetry
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.base_ref }}
+      - name: Get base package version
+        id: version-base
+        run: echo "version=`poetry version --short --no-interaction`" >> $GITHUB_OUTPUT
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
+      - name: Get head package version
+        id: version-head
+        run: echo "version=`poetry version --short --no-interaction`" >> $GITHUB_OUTPUT
+
+  bump-version:
+    # Bumps the package version, if not already changed from the base branch.
+    runs-on: ubuntu-latest
+    needs: [diff, versions]
+    outputs:
+      version: ${{ steps.get-version.outputs.version }}
+      commit_long_sha: ${{ steps.commit.outputs.commit_long_sha }}
+    # Only bump for pull requests, where src/deps have changed, and either for
+    # dependabot PRs or when PR title begins with the version level to bump.
+    if: |
+      github.event_name == 'pull_request'
+      && needs.diff.outputs.src_changed > 0
+      && needs.versions.outputs.version_base == needs.versions.outputs.version_head
+      && (
+        github.actor == 'dependabot[bot]'
+        || startsWith(github.event.pull_request.title, 'Patch')
+        || startsWith(github.event.pull_request.title, 'Minor')
+        || startsWith(github.event.pull_request.title, 'Major')
+      )
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ inputs.python-version }}
+      - run: pipx install poetry
+      - name: Patch
+        if: github.actor == 'dependabot[bot]' || startsWith(github.event.pull_request.title, 'Patch')
+        run: poetry version patch --no-interaction
+      - name: Minor
+        if: startsWith(github.event.pull_request.title, 'Minor')
+        run: poetry version minor --no-interaction
+      - name: Major
+        if: startsWith(github.event.pull_request.title, 'Major')
+        run: poetry version major --no-interaction
+      - name: Commit
+        uses: EndBug/add-and-commit@v9
+        id: commit
+        with:
+          add: 'pyproject.toml poetry.lock'
+          message: "Auto-bump package version."
+      - name: Get new version
+        id: get-version
+        run: echo "version=`poetry version --short --no-interaction`" >> $GITHUB_OUTPUT
+
+  build:
+    # Check that the package builds successfully.
+    # Do not cache the build, as at this stage the version may not be bumped,
+    # and we re-build when publishing anyway.
+    runs-on: ubuntu-latest
+    needs: [diff, bump-version]
+    outputs:
+      version: ${{ steps.output-version.outputs.version }}
+    # Run even if bump-version skipped, but not on failures.
+    if: |
+      always()
+      && needs.diff.outputs.src_changed > 0
+      && !contains(needs.*.result, 'failure')
+      && !contains(needs.*.result, 'cancelled')
+    steps:
+      - name: Checkout
+        if: needs.bump-version.result == 'skipped'
+        uses: actions/checkout@v3
+      - name: Checkout bumped version
+        if: needs.bump-version.result == 'success'
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.bump-version.outputs.commit_long_sha }}
+      - uses: scene-connect/actions/python-package-manager/install-dependencies@v2
+        with:
+          package-manager: poetry
+          python-version: ${{ inputs.python-version }}
+      - name: Build
+        run: poetry build --no-interaction
+      - name: Output version
+        id: output-version
+        run: echo "version=`poetry version --short --no-interaction`" >> $GITHUB_OUTPUT
+
+  repo-version-check:
+    runs-on: ubuntu-latest
+    needs: [diff, bump-version, build]
+    # Run even if bump-version skipped, but not on failures.
+    if: |
+      always()
+      && needs.diff.outputs.src_changed > 0
+      && !contains(needs.*.result, 'failure')
+      && !contains(needs.*.result, 'cancelled')
+    steps:
+      - name: Authenticate with Google Cloud
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: ${{ secrets.GOOGLE_AUTHENTICATION_CREDENTIALS_JSON }}
+      - name: Get version description in Google Artifact Registry
+        id: artifact_registry
+        run: |
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "description<<$EOF" >> $GITHUB_OUTPUT
+          echo "`gcloud artifacts versions describe \
+          ${{ needs.build.outputs.version }} \
+          --package=zuos-types \
+          --repository=zuos-python-repo \
+          --location=europe-north1 \
+          `" >> $GITHUB_OUTPUT
+          echo "$EOF" >> $GITHUB_OUTPUT
+      - name: Check version
+        if: contains(steps.artifact_registry.outputs.description, 'createTime')
+        uses: actions/github-script@v3
+        with:
+          script: |
+            core.setFailed(
+              "Package version ${{ needs.build.outputs.version }} already exists in the artifact registry!"
+            )
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: [build, repo-version-check]
+    # Run even if bump-version skipped, but not on failures.
+    if: |
+      always()
+      && needs.diff.outputs.src_changed > 0
+      && !contains(needs.*.result, 'failure')
+      && !contains(needs.*.result, 'cancelled')
+      && (github.event_name == 'workflow_dispatch'
+        || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+      )
+    steps:
+      - uses: actions/checkout@v3
+      - name: Authenticate with Google Cloud
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: ${{ secrets.GOOGLE_AUTHENTICATION_CREDENTIALS_JSON }}
+      - name: Install dependencies
+        uses: scene-connect/actions/python-package-manager/install-dependencies@v2
+        with:
+          package-manager: poetry
+          python-version: ${{ inputs.python-version }}
+      - name: Publish
+        run: poetry publish --build --repository=zuos-python-repo --no-interaction -vvv

--- a/README.md
+++ b/README.md
@@ -1,2 +1,44 @@
 # actions
-Reusable GitHub Actions workflows
+Reusable GitHub actions and workflows.
+
+## Workflows
+
+### lint-python.yml
+
+Our python linting checks. Configurable
+
+### poetry-publish.yml
+
+Automatically build and publish a poetry package to our private Google Artifact Registry.
+Compatible with repos based on our `scene-connect/zuos-python-package-template`.
+
+Features:
+- Checks for relevant changes.
+- Automatically bump the package version by prefixing the PR title with:
+  - Patch, Minor, Major
+  - Automatically bumps version patch leve for `dependabot` PRs.
+- Builds the package to check everything works.
+- Checks if the (bumped) package version already exists in the Artifact Registry
+  (you'll have to set your own version to resolve conflicts)
+- Publishes the package on merge to main.
+
+## Actions
+
+### install-system-dependencies
+
+A simple action to install system/os level dependencies (using `apt-get`).
+
+### python-package-manager
+
+Common actions for performing actions with a variety of python package managers.
+Actions in here mostly use sub-actions to perform the task with different package
+managers, and an overall action to switch on a `package-manager` input.
+
+#### install-dependencies
+
+Install a project's dependencies for CI workflows.
+
+#### run-command
+
+Run a command, within the project venv set up by `install-dependences`.
+Useful in shared actions which themselves use a `package-manager` input.


### PR DESCRIPTION
Auto-bumps the package version if set in the PR title (or for dependabot). Checks the version has not already been published. Publishes on push to main.