### PR TITLE
Forgot part of the docker tags

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -59,7 +59,9 @@ jobs:
           file: Dockerfile
           platforms: linux/amd64
           push: ${{ inputs.docker-push }}
-          tags: ${{ env.full_image_uri }}-builder:latest
+          tags: |
+            ${{ env.full_image_uri }}-builder:latest
+            ${{ env.full_image_uri }}-builder:${{ github.sha }}
           target: builder
           secret-files: |
             "google_application_credentials.json=/tmp/google_auth_credentials.json"
@@ -72,7 +74,9 @@ jobs:
           file: Dockerfile
           platforms: linux/amd64
           push: ${{ inputs.docker-push }}
-          tags: ${{ env.full_image_uri }}:latest
+          tags: |
+            ${{ env.full_image_uri }}:latest
+            ${{ env.full_image_uri }}:${{ github.sha }}
           secret-files: |
             "google_application_credentials.json=/tmp/google_auth_credentials.json"
 


### PR DESCRIPTION
I forgot to tag docker images also with the git hash. And this failed kubernetes deployment since that is how we used in the image deployment.  We should setup alerts for that. But at least this fixes it (tested already)