### PR TITLE
Fix poetry publish

### DIFF
--- a/.github/workflows/poetry-publish.yml
+++ b/.github/workflows/poetry-publish.yml
@@ -24,13 +24,12 @@ jobs:
     # Check for changes which should trigger a new build/publish
     runs-on: ubuntu-latest
     outputs:
-      src_changed: ${{ steps.diff.outputs.lines }}
+      src_changed: ${{ steps.diff.outputs.count }}
     steps:
       - uses: actions/checkout@v3
       - uses: technote-space/get-diff-action@v6
         id: diff
         with:
-          GET_FILE_DIFF: true
           PATTERNS: |
             src/**/*
           FILES: |

--- a/.github/workflows/poetry-publish.yml
+++ b/.github/workflows/poetry-publish.yml
@@ -35,7 +35,7 @@ jobs:
             src/**/*
           FILES: |
             pyproject.toml
-            pyproject.lock
+            poetry.lock
 
   versions:
     # Gets the package version from the base and head branches.


### PR DESCRIPTION
*   Wrong filename in poetry-publish diff
*   Use diff count not lines, we only care if files were changed, not by how much.

- [ ] Tag v2 and minor version after merge