### PR TITLE
Simplify poetry verison check

### DIFF
--- a/.github/workflows/poetry-publish.yml
+++ b/.github/workflows/poetry-publish.yml
@@ -159,26 +159,10 @@ jobs:
         uses: google-github-actions/auth@v1
         with:
           credentials_json: ${{ secrets.GOOGLE_AUTHENTICATION_CREDENTIALS_JSON }}
-      - name: Get version description in Google Artifact Registry
+      - name: Fail if the current version exists in Google Artifact Registry
         id: artifact_registry
         run: |
-          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-          echo "description<<$EOF" >> $GITHUB_OUTPUT
-          echo "`gcloud artifacts versions describe \
-          ${{ needs.build.outputs.version }} \
-          --package=${{ needs.build.outputs.package_name }} \
-          --repository=${{ inputs.repository }} \
-          --location=${{ inputs.location }} \
-          `" >> $GITHUB_OUTPUT
-          echo "$EOF" >> $GITHUB_OUTPUT
-      - name: Check version
-        if: contains(steps.artifact_registry.outputs.description, 'createTime')
-        uses: actions/github-script@v3
-        with:
-          script: |
-            core.setFailed(
-              "Package version ${{ needs.build.outputs.version }} already exists in the artifact registry!"
-            )
+          gcloud artifacts versions list --package=${{ needs.build.outputs.package_name }} --repository=${{ inputs.repository }} --location=${{ inputs.location }}| ( ! grep -q ${{ needs.build.outputs.version }} )
 
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/poetry-publish.yml
+++ b/.github/workflows/poetry-publish.yml
@@ -42,6 +42,7 @@ jobs:
     outputs:
       version_base: ${{ steps.version-base.outputs.version }}
       version_head: ${{ steps.version-head.outputs.version }}
+      version_artifact_registry_exists: ${{ steps.version-artifact-registry.outputs.exists }}
     steps:
       - uses: actions/setup-python@v4
         with:
@@ -56,9 +57,20 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.head_ref }}
+      - name: Authenticate with Google Cloud
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: ${{ secrets.GOOGLE_AUTHENTICATION_CREDENTIALS_JSON }}
+      - name: Output package name
+        id: package_name
+        run: echo "package_name=`poetry version --no-interaction | grep -Po '^([\w-]+)(?=\s+.*)'`" >> $GITHUB_OUTPUT
       - name: Get head package version
         id: version-head
         run: echo "version=`poetry version --short --no-interaction`" >> $GITHUB_OUTPUT
+      - name: Check if the head version exists in Google Artifact Registry
+        id: version-artifact-registry
+        run: |
+          gcloud artifacts versions list --package=${{ steps.package_name.outputs.package_name }} --repository=${{ inputs.repository }} --location=${{ inputs.location }}| grep -q ${{ steps.version-head.outputs.version }} && echo "exists=1" >> $GITHUB_OUTPUT || echo "exists=0" >> $GITHUB_OUTPUT
 
   bump-version:
     # Bumps the package version, if not already changed from the base branch.
@@ -70,15 +82,9 @@ jobs:
     # Only bump for pull requests, where src/deps have changed, and either for
     # dependabot PRs or when PR title begins with the version level to bump.
     if: |
-      github.event_name == 'pull_request'
+      ( github.event_name == 'pull_request' || github.event_name ==  'workflow_dispatch' )
       && needs.diff.outputs.src_changed > 0
-      && needs.versions.outputs.version_base == needs.versions.outputs.version_head
-      && (
-        github.actor == 'dependabot[bot]'
-        || startsWith(github.event.pull_request.title, 'Patch')
-        || startsWith(github.event.pull_request.title, 'Minor')
-        || startsWith(github.event.pull_request.title, 'Major')
-      )
+      && ( needs.versions.outputs.version_base == needs.versions.outputs.version_head || needs.versions.outputs.version_artifact_registry_exists )
     steps:
       - uses: actions/checkout@v3
         with:
@@ -87,15 +93,8 @@ jobs:
         with:
           python-version: ${{ inputs.python-version }}
       - run: pipx install poetry
-      - name: Patch
-        if: github.actor == 'dependabot[bot]' || startsWith(github.event.pull_request.title, 'Patch')
-        run: poetry version patch --no-interaction
-      - name: Minor
-        if: startsWith(github.event.pull_request.title, 'Minor')
+      - name: Bump version number one minor version
         run: poetry version minor --no-interaction
-      - name: Major
-        if: startsWith(github.event.pull_request.title, 'Major')
-        run: poetry version major --no-interaction
       - name: Commit
         uses: EndBug/add-and-commit@v9
         id: commit
@@ -143,30 +142,9 @@ jobs:
         id: output-version
         run: echo "version=`poetry version --short --no-interaction`" >> $GITHUB_OUTPUT
 
-  repo-version-check:
-    runs-on: ubuntu-latest
-    needs: [diff, bump-version, build]
-    # Run even if bump-version skipped, but not on failures.
-    if: |
-      always()
-      && needs.diff.outputs.src_changed > 0
-      && !contains(needs.*.result, 'failure')
-      && !contains(needs.*.result, 'cancelled')
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Authenticate with Google Cloud
-        uses: google-github-actions/auth@v1
-        with:
-          credentials_json: ${{ secrets.GOOGLE_AUTHENTICATION_CREDENTIALS_JSON }}
-      - name: Fail if the current version exists in Google Artifact Registry
-        id: artifact_registry
-        run: |
-          gcloud artifacts versions list --package=${{ needs.build.outputs.package_name }} --repository=${{ inputs.repository }} --location=${{ inputs.location }}| ( ! grep -q ${{ needs.build.outputs.version }} )
-
   publish:
     runs-on: ubuntu-latest
-    needs: [build, repo-version-check]
+    needs: [build]
     # Run even if bump-version skipped, but not on failures.
     if: |
       always()


### PR DESCRIPTION
This changes the poetry version bumping.
* Before version bump only ran if the pull request was opened with Patch|Minor|Major in the title. If the PR title was changed after, and a manual workflow run was done, the version wouldn't get bumped anymore. The only solution was to close and reopen the PR.
* Now the version bump runs with manual workflow_dispatch, PR opening and PR closing (merging) and also on commits to the PR. 
* The version will just always be a Minor number up. But if you manually bump the version number locally to a patch or major version, the version won't be bumped anymore.
* It bumps the version number if the current branch's version number is the same as the main version number, or if the current branch's version number exists in the gcloud artifact repository.
* There is no pre-publish version number check anymore, since it will have bumped the version number also if the current version exists in gcloud artifact repo

It could be made more resilitient still by first checking the highest version number between the base branch and the gcloud version, setrting the version number to that one, and then doing a bump one minor version up, so we don't run the risk of the current PR being 2 versions or more behind. But it will fail to publish anyway if the version already exists, and you can also manually set it in a branch, or run another manual workflow_dispatch. 

You can safely test it with this PR, that is just a bogus PR so anyone can push/pull to it to their hearts desire for testing: https://github.com/scene-connect/zuos-utilities/pull/110