### PR TITLE
Remove diff check from pre-commit autoupdate workflow.

### DIFF
--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -1,4 +1,4 @@
-name: Pre-commit auto-update
+name: pre-commit autoupdate
 on:
   workflow_call:
     inputs:
@@ -57,19 +57,12 @@ jobs:
         with:
           command: pre-commit autoupdate
           package-manager: ${{ inputs.package-manager }}
-      - uses: technote-space/get-diff-action@v6
-        id: diff
-        with:
-          FILES: |
-            .pre-commit-config.yaml
       - name: Check hooks still pass
         uses: scene-connect/actions/python-package-manager/run-command@v2
-        if: env.GIT_DIFF
         with:
           command: pre-commit run --all-files
           package-manager: ${{ inputs.package-manager }}
       - uses: peter-evans/create-pull-request@v5
-        if: env.GIT_DIFF
         with:
           token: ${{ secrets.PRE_COMMIT_AUTO_UPDATE_ACCESS_TOKEN }}
           branch: "pre-commit-autoupdate"

--- a/.github/workflows/self-pre-commit-autoupdate.yml
+++ b/.github/workflows/self-pre-commit-autoupdate.yml
@@ -1,0 +1,11 @@
+name: pre-commit autoupdate
+on:
+  schedule:
+    - cron: "0 0 * * 0"  # midnight every sunday
+  workflow_dispatch:
+
+jobs:
+  autoupdate:
+    uses: scene-connect/actions/.github/workflows/pre-commit-autoupdate.yml@v2
+    secrets:
+      PRE_COMMIT_AUTO_UPDATE_ACCESS_TOKEN: ${{ secrets.PRE_COMMIT_AUTO_UPDATE_ACCESS_TOKEN }}


### PR DESCRIPTION
Action is not intended for checking for un-committed changes, and doesn't seem to be configurable as such.

Also adds self-pre-commit-autoupdate.yml to update pre-commit in the actions repo itself.

---

After merge:
- [ ] Tag `v2` and minor version