### PR TITLE
Fix pre commit venv

### DIFF
--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -50,8 +50,13 @@ jobs:
           python-version: ${{ inputs.python-version }}
           requirements-files: ${{ inputs.requirements-files }}
           system-dependencies: ${{ inputs.system-dependencies }}
+      - name: Add symlink to local .venv
+        # So that the pyright pre-commit hook runs with the dependencies in the venv.
+        if: inputs.package-manager == 'pipenv'
+        run: ln -s `pipenv --venv` .venv
 
       # Update pre-commit hooks and create a PR
+
       - name: pre-commit autoupdate
         uses: scene-connect/actions/python-package-manager/run-command@v2
         with:

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -63,9 +63,14 @@ jobs:
           command: pre-commit run --all-files
           package-manager: ${{ inputs.package-manager }}
       - uses: peter-evans/create-pull-request@v5
+        id: pr
         with:
           token: ${{ secrets.PRE_COMMIT_AUTO_UPDATE_ACCESS_TOKEN }}
           branch: "pre-commit-autoupdate"
           title: "pre-commit autoupdate"
           commit-message: "pre-commit autoupdate"
           add-paths: .pre-commit-config.yaml
+      - name: Enable PR automerge
+        run: gh pr merge --merge --auto "${{ steps.pr.outputs.pull-request-number }}"
+        env:
+          GH_TOKEN: ${{ secrets.PRE_COMMIT_AUTO_UPDATE_ACCESS_TOKEN }}

--- a/python-package-manager/install-dependencies/pipenv/action.yml
+++ b/python-package-manager/install-dependencies/pipenv/action.yml
@@ -8,11 +8,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Remove local .venv
-      # setup-python only caches .local/share/virtualenvs
-      # We add a symlink back later, so the pyright can property use the correct .venv
-      run: rm -rf .venv
-      shell: bash
     - uses: actions/setup-python@v4
       with:
         cache: "pipenv"
@@ -27,7 +22,4 @@ runs:
       shell: bash
     - name: Install pipenv dependencies
       run: pipenv install --dev --deploy
-      shell: bash
-    - name: Add symlink back to local .venv
-      run: ln -s `pipenv --venv` .venv
       shell: bash


### PR DESCRIPTION
```
commit b89bc3a9956814c19a572760825305812c54d278 (HEAD -> fix-pre-commit-venv, origin/fix-pre-commit-venv)
Author: Howard Cox <dev.anubis@gmail.com>
Date:   Thu Nov 2 14:49:45 2023 +0000

    Moves the .venv hackery for pipenv dependencies.
    
    The local .venv directory is only necessary for running the pyright
    pre-commit hook.
    
    This should be a major version bump for the actions, and repos will
    need updating to remove their .venv/README.rst placeholder and add
    .venv to their .gitignore so that they don't run into git stash
    conflcits whilst running the pre-commit-autpupdate workflow.

commit 45b90779f561fd2907c87abbe28bb02fc01723a3
Author: Howard Cox <dev.anubis@gmail.com>
Date:   Thu Nov 2 14:32:26 2023 +0000

    Enable automerge for pre-commit autoupdate PRs
```

---

Related PR in common-data to use this new local .venv layout: scene-connect/zuos-common-data#337

TODO after merge:

*   [ ] git tag v3
*   [ ] git tag v3.0.0
*   [ ] git push --tag