### PR TITLE
Sets required write permissions for poetry-publish workflow.

### DIFF
--- a/.github/workflows/poetry-publish.yml
+++ b/.github/workflows/poetry-publish.yml
@@ -19,6 +19,10 @@ on:
         description: "Google Cloud Platform service-agent JSON credentials for accessing our Artifact Repository and installing private packages."
         required: false
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   diff:
     # Check for changes which should trigger a new build/publish


### PR DESCRIPTION
TODO after merge:

*   [ ] git tag v3
*   [ ] git tag 3.1
*   [ ] Update repos to use v3 (needed anyway for the recent pre-commit-autoupdate changes)
    * Repos also need to pass the permissions into the workflow call, see: https://github.com/scene-connect/zuos-utilities/pull/116