### PR TITLE
Adds github PAT for bumping poetry version.

### DIFF
--- a/.github/workflows/poetry-publish.yml
+++ b/.github/workflows/poetry-publish.yml
@@ -15,13 +15,12 @@ on:
         required: false
         type: string
     secrets:
+      POETRY_BUMP_VERSION_PAT:
+        description: "Github Personal Access Token to use for the version-bump step. Should grant access to commit and trigger actions."
+        required: true
       GOOGLE_AUTHENTICATION_CREDENTIALS_JSON:
         description: "Google Cloud Platform service-agent JSON credentials for accessing our Artifact Repository and installing private packages."
-        required: false
-
-permissions:
-  contents: write
-  pull-requests: write
+        required: true
 
 jobs:
   diff:
@@ -93,6 +92,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.POETRY_BUMP_VERSION_PAT }}
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ inputs.python-version }}


### PR DESCRIPTION
To trigger github actions this MUST be ran as a user using a PAT, the normal GITHUB_TOKEN does not have permission to trigger actions (to prevent infinite loops).

We know we want to trigger a CI run after bumping the version, and the version should NOT bump twice, so it's safe.