### PR TITLE
Skip ci for the poetry version bump automatic commit.

### DIFF
--- a/.github/workflows/poetry-publish.yml
+++ b/.github/workflows/poetry-publish.yml
@@ -104,7 +104,7 @@ jobs:
         id: commit
         with:
           add: "pyproject.toml poetry.lock"
-          message: "Auto-bump package version."
+          message: "[skip ci] Auto-bump package version."
       - name: Get new version
         id: get-version
         run: echo "version=`poetry version --short --no-interaction`" >> $GITHUB_OUTPUT


### PR DESCRIPTION
We don't need to re-run our entire CI workflow with linting and tests just because we bump the package version.