### PR TITLE
Optionally auto-merge major versions of dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,6 +1,12 @@
 name: Dependabot auto-merge
 on:
   workflow_call:
+    inputs:
+      merge_major_versions:
+        default: false
+        description: Auto merge on major version changes
+        required: false
+        type: boolean
 
 permissions:
   pull-requests: write
@@ -22,5 +28,5 @@ jobs:
       - name: Approve PR
         run: gh pr review --approve "$PR_URL"
       - name: Merge PR
-        if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major' }}
+        if: ${{ inputs.merge_major_versions || steps.metadata.outputs.update-type != 'version-update:semver-major' }}
         run: gh pr merge --auto --squash "$PR_URL"

--- a/.github/workflows/local-actions-dependabot-auto-merge.yml
+++ b/.github/workflows/local-actions-dependabot-auto-merge.yml
@@ -3,5 +3,6 @@ on: pull_request_target
 
 jobs:
   dependabot-auto-merge:
-    uses:
-      ./.github/workflows/dependabot-auto-merge.yml
+    uses: ./.github/workflows/dependabot-auto-merge.yml
+    with:
+      merge_major_versions: true


### PR DESCRIPTION
In order to be able to specify whether major version changes from dependabot should be auto merged, I added an option that by default doesnt change anything but with our github actions, auto-merges PRs with major versions. These changes wont ever be used until we tag the actions version, and the other repos start using that new tag, so we can always point to the older version if a CI pipeline breaks.