### PR TITLE
Remove check for prerelease version

### DIFF
--- a/.github/workflows/poetry-version-check.yml
+++ b/.github/workflows/poetry-version-check.yml
@@ -59,9 +59,6 @@ jobs:
       - run: pip install packaging
       - name: Head poetry version newer than base
         run: python -c "from packaging import version;import sys;sys.exit( 0 if version.parse('${{ needs.versions.outputs.version-head }}') > version.parse('${{ needs.versions.outputs.version-base }}') else 1)"
-      - name: main - not a pre-release version
-        if: github.base_ref == 'main'
-        run: python -c "from packaging import version;import sys;sys.exit( 1 if version.parse('${{ needs.versions.outputs.version-head }}').is_prerelease else 0)"
 
   version-check-git-tag:
     name: Version check - git tag


### PR DESCRIPTION
We shouldnt check that a PR to main isn't a prerelease version because during the testing of staging we will have `rc0` and higher versions in the release branch, which also qualify as pre-release. So  this check blocks the CI pipeline.