### PR TITLE
Set github runner to ubuntu-22.04

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   dependabot-auto-merge:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: ${{ github.actor == 'dependabot[bot]' }}
     env:
       PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -35,7 +35,7 @@ env:
   full_image_uri: europe-north1-docker.pkg.dev/${{ inputs.gcp-project }}/${{ inputs.image-repo-name }}/${{ inputs.image-name }}
 jobs:
   docker_build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       DOCKER_BUILDKIT: 1
     steps:
@@ -81,7 +81,7 @@ jobs:
             "google_application_credentials.json=/tmp/google_auth_credentials.json"
 
   kubernetes_deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [docker_build]
     if: |
       inputs.deployment-name != ''

--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -81,7 +81,7 @@ on:
 jobs:
   black:
     if: inputs.black
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -102,7 +102,7 @@ jobs:
 
   django-upgrade:
     if: inputs.django-upgrade
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -116,7 +116,7 @@ jobs:
 
   flake8:
     if: inputs.flake8
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -140,7 +140,7 @@ jobs:
 
   isort:
     if: inputs.isort
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Authenticate with Google Cloud
@@ -165,7 +165,7 @@ jobs:
 
   mypy:
     if: inputs.mypy
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Authenticate with Google Cloud
@@ -204,7 +204,7 @@ jobs:
 
   pyright:
     if: inputs.pyright
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Authenticate with Google Cloud
@@ -229,7 +229,7 @@ jobs:
 
   pyupgrade:
     if: inputs.pyupgrade
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -243,7 +243,7 @@ jobs:
 
   reorder-python-imports:
     if: inputs.reorder-python-imports
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -264,7 +264,7 @@ jobs:
 
   ruff:
     if: inputs.ruff
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - id: get_version

--- a/.github/workflows/poetry-build-publish.yml
+++ b/.github/workflows/poetry-build-publish.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   build-publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/poetry-version-check.yml
+++ b/.github/workflows/poetry-version-check.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   versions:
     # Gets the package version from the base and head branches.
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: |
       github.event_name == 'pull_request'
       && github.actor != 'dependabot[bot]'
@@ -51,7 +51,7 @@ jobs:
   version-check:
     name: Version check
     needs: [versions]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/setup-python@v5
         with:
@@ -65,7 +65,7 @@ jobs:
 
   version-check-git-tag:
     name: Version check - git tag
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [versions]
     steps:
       - uses: actions/checkout@v4
@@ -83,7 +83,7 @@ jobs:
 
   version-check-repo:
     name: Version check - package repo
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [versions]
     steps:
       - name: Authenticate with Google Cloud


### PR DESCRIPTION
ubuntu-latest (24.04) has newer version of pip which blocks installing packages outside of a venv, which our actions and some  
upstream actions we use rely on.

Quickest to roll back the runner version for the short-term until the upstream actions are patched.

actions/setup-python#952

---

TODO after merge:

*   [ ] Tag v5.2.1
*   [ ] Tag v5.2
*   [ ] Tag v5