### PR TITLE
Adds an action to check a PR is up to date.

### DIFF
--- a/check_pr_up_to_date/action.yml
+++ b/check_pr_up_to_date/action.yml
@@ -1,0 +1,16 @@
+name: Check PR is up to date with the base branch
+description: Useful for halting CI workflows if the PR branch needs updating.
+
+runs:
+  using: "composite"
+  steps:
+    - name: Git checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Check if up to date with the base
+      shell: bash
+      run: |
+        if ! git merge-base --is-ancestor ${{ github.event.pull_request.base.ref }} ${{ github.event.pull_request.head.sha }};
+        then echo "This branch is not up to date with ${{ github.event.pull_request.base.ref }}";
+        exit 1; fi


### PR DESCRIPTION
This is mostly so we can use this as the first step in every CI workflow, to avoid running CI at all if the PR is not up to date with the base branch.

This might also aid in catching dependabot when it creates it's next PR before the last has actually merged...