### PR TITLE
Fix poetry package caching

### DIFF
--- a/python-package-manager/get_package_version/action.yml
+++ b/python-package-manager/get_package_version/action.yml
@@ -35,10 +35,8 @@ runs:
       if: inputs.package-manager == 'poetry'
       with:
         python-version: ${{ inputs.python-version }}
-    - name: Install poetry
+    - uses: abatilo/actions-poetry@v3
       if: inputs.package-manager == 'poetry'
-      run: pipx install poetry
-      shell: bash
     - id: get_version
       run: echo "version=`$GITHUB_ACTION_PATH/get_version.sh`" >> $GITHUB_OUTPUT
       env:

--- a/python-package-manager/install-dependencies/pip/action.yml
+++ b/python-package-manager/install-dependencies/pip/action.yml
@@ -16,7 +16,7 @@ runs:
     - uses: actions/setup-python@v4
       with:
         cache: "pip"
-        python-version: "3.11"
+        python-version: ${{ inputs.python-version }}
     - name: Prepare Google Artifact Registry keyring
       if: env.GOOGLE_APPLICATION_CREDENTIALS
       # Install dependencies for accessing our private packages repo (keyring for authenticating to GCP Artifact Registry).

--- a/python-package-manager/install-dependencies/pipenv/action.yml
+++ b/python-package-manager/install-dependencies/pipenv/action.yml
@@ -11,7 +11,7 @@ runs:
     - uses: actions/setup-python@v4
       with:
         cache: "pipenv"
-        python-version: "3.11"
+        python-version: ${{ inputs.python-version }}
     - name: Install pipenv
       run: pip install pipenv
       shell: bash

--- a/python-package-manager/install-dependencies/poetry/action.yml
+++ b/python-package-manager/install-dependencies/poetry/action.yml
@@ -14,7 +14,7 @@ runs:
   steps:
     - uses: actions/setup-python@v5
       with:
-        python-version: "3.11"
+        python-version: ${{ inputs.python-version }}
     - uses: abatilo/actions-poetry@v3
     - uses: actions/cache@v4
       name: Setup cache

--- a/python-package-manager/install-dependencies/poetry/action.yml
+++ b/python-package-manager/install-dependencies/poetry/action.yml
@@ -12,13 +12,17 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Install poetry
-      run: pipx install poetry
-      shell: bash
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
-        cache: "poetry"
         python-version: "3.11"
+    - uses: abatilo/actions-poetry@v3
+    - uses: actions/cache@v4
+      name: Setup cache
+      with:
+        path: ./.venv
+        key: poetry-lock-${{ hashFiles('poetry.lock') }}
+        # We always set "in-project" in poetry.toml to ensure a local .venv, as
+        # we require that for pyright and other pre-commit hooks.
     - name: Prepare Google Artifact Registry keyring
       if: env.GOOGLE_APPLICATION_CREDENTIALS
       # Install dependencies for accessing our private packages repo (keyring for authenticating to GCP Artifact Registry).


### PR DESCRIPTION
```
commit 0eec9246903bdf07e85638ccf9a43eeb17b46044 (HEAD -> poetry-cache-fixes, origin/poetry-cache-fixes)
Author: Howard Cox <dev.anubis@gmail.com>
Date:   Fri Nov 15 16:40:16 2024 +0000

    Install poetry with action instead of pipx

commit 3af07df641cc119db004948cc8ea610f02d1b52b
Author: Howard Cox <dev.anubis@gmail.com>
Date:   Fri Nov 15 16:37:17 2024 +0000

    Fix python-version to use inputs not fixed values

commit c7c33e4b6647e19597432ebf65696cdaf61af07e
Author: Howard Cox <dev.anubis@gmail.com>
Date:   Fri Nov 15 16:35:54 2024 +0000

    Fix poetry package caching.
    
    It seems setup-python only caches venvs/dependencies if NOT using a local .venv,
    which we do to get pyright etc.
```