### PR TITLE
Add poetry groups

### DIFF
--- a/python-package-manager/install-dependencies/action.yml
+++ b/python-package-manager/install-dependencies/action.yml
@@ -22,6 +22,9 @@ inputs:
   system-dependencies:
     required: false
     type: string
+  groups:
+    required: false
+    type: string
 
 runs:
   using: "composite"
@@ -48,3 +51,4 @@ runs:
       with:
         with_root: ${{ inputs.with_root }}
         python-version: ${{ inputs.python-version }}
+        groups: ${{ inputs.groups }}

--- a/python-package-manager/install-dependencies/action.yml
+++ b/python-package-manager/install-dependencies/action.yml
@@ -47,7 +47,7 @@ runs:
         python-version: ${{ inputs.python-version }}
     - name: Install poetry requirements
       if: inputs.package-manager == 'poetry'
-      uses: scene-connect/actions/python-package-manager/install-dependencies/poetry@v5
+      uses: scene-connect/actions/python-package-manager/install-dependencies/poetry@add_poetry_groups
       with:
         with_root: ${{ inputs.with_root }}
         python-version: ${{ inputs.python-version }}

--- a/python-package-manager/install-dependencies/poetry/action.yml
+++ b/python-package-manager/install-dependencies/poetry/action.yml
@@ -33,7 +33,7 @@ runs:
       shell: bash
     - name: Install poetry dependencies
       if: inputs.with_root == 'false' && inputs.groups != ''
-      run: poetry install --all-extras --no-interaction --no-root --with=inputs.groups
+      run: poetry install --all-extras --no-interaction --no-root --with=${{ inputs.groups }}
       shell: bash
     - name: Install poetry dependencies
       if: inputs.with_root == 'false' && inputs.groups == ''
@@ -41,7 +41,7 @@ runs:
       shell: bash
     - name: Install poetry dependencies with root
       if: inputs.with_root == 'true' && inputs.groups != ''
-      run: poetry install --all-extras --no-interaction --with=inputs.groups
+      run: poetry install --all-extras --no-interaction --with=${{ inputs.groups }}
       shell: bash
     - name: Install poetry dependencies with root
       if: inputs.with_root == 'true' && inputs.groups == ''

--- a/python-package-manager/install-dependencies/poetry/action.yml
+++ b/python-package-manager/install-dependencies/poetry/action.yml
@@ -8,6 +8,10 @@ inputs:
     default: false
     required: false
     type: boolean
+  groups:
+    default: ""
+    required: false
+    type: string
 
 runs:
   using: "composite"
@@ -29,10 +33,18 @@ runs:
       run: poetry self add "keyrings-google-artifactregistry-auth@latest"
       shell: bash
     - name: Install poetry dependencies
-      if: inputs.with_root == 'false'
+      if: inputs.with_root == 'false' && inputs.groups != ""
+      run: poetry install --all-extras --no-interaction --no-root --with=inputs.groups
+      shell: bash
+    - name: Install poetry dependencies
+      if: inputs.with_root == 'false' && inputs.groups == ""
       run: poetry install --all-extras --no-interaction --no-root
       shell: bash
     - name: Install poetry dependencies with root
-      if: inputs.with_root == 'true'
+      if: inputs.with_root == 'true' && inputs.groups != ""
+      run: poetry install --all-extras --no-interaction --with=input.groups
+      shell: bash
+    - name: Install poetry dependencies with root
+      if: inputs.with_root == 'true' && inputs.groups == ""
       run: poetry install --all-extras --no-interaction
       shell: bash

--- a/python-package-manager/install-dependencies/poetry/action.yml
+++ b/python-package-manager/install-dependencies/poetry/action.yml
@@ -9,7 +9,6 @@ inputs:
     required: false
     type: boolean
   groups:
-    default: ""
     required: false
     type: string
 
@@ -33,18 +32,18 @@ runs:
       run: poetry self add "keyrings-google-artifactregistry-auth@latest"
       shell: bash
     - name: Install poetry dependencies
-      if: inputs.with_root == 'false' && inputs.groups != ""
+      if: inputs.with_root == 'false' && inputs.groups != ''
       run: poetry install --all-extras --no-interaction --no-root --with=inputs.groups
       shell: bash
     - name: Install poetry dependencies
-      if: inputs.with_root == 'false' && inputs.groups == ""
+      if: inputs.with_root == 'false' && inputs.groups == ''
       run: poetry install --all-extras --no-interaction --no-root
       shell: bash
     - name: Install poetry dependencies with root
-      if: inputs.with_root == 'true' && inputs.groups != ""
+      if: inputs.with_root == 'true' && inputs.groups != ''
       run: poetry install --all-extras --no-interaction --with=input.groups
       shell: bash
     - name: Install poetry dependencies with root
-      if: inputs.with_root == 'true' && inputs.groups == ""
+      if: inputs.with_root == 'true' && inputs.groups == ''
       run: poetry install --all-extras --no-interaction
       shell: bash

--- a/python-package-manager/install-dependencies/poetry/action.yml
+++ b/python-package-manager/install-dependencies/poetry/action.yml
@@ -41,7 +41,7 @@ runs:
       shell: bash
     - name: Install poetry dependencies with root
       if: inputs.with_root == 'true' && inputs.groups != ''
-      run: poetry install --all-extras --no-interaction --with=input.groups
+      run: poetry install --all-extras --no-interaction --with=inputs.groups
       shell: bash
     - name: Install poetry dependencies with root
       if: inputs.with_root == 'true' && inputs.groups == ''


### PR DESCRIPTION
This allows us to install optional dependency groups (as opposed to extras).

For instance 

```
    with:
        groups="docs"
```

results in poetry installing with

```
poetry install --with="docs"
```

Groups are nice for installing sets of (optional or required) packages. It also interacts nicely with `poetry export`.